### PR TITLE
Added Base Url Interceptor

### DIFF
--- a/lib/api/api_client.dart
+++ b/lib/api/api_client.dart
@@ -1,4 +1,5 @@
 import 'package:dio/dio.dart';
+import 'package:flrx/src/api/interceptors/base_url_interceptor.dart';
 
 class ApiClient extends Dio {
   ApiClient({BaseOptions options}) : super(options) {
@@ -9,6 +10,7 @@ class ApiClient extends Dio {
         requestHeader: true,
         responseBody: true,
         responseHeader: true));
+    interceptors.add(BaseUrlInterceptor());
   }
 
   void setDefaultHeader(Map<String, String> headers) {

--- a/lib/src/api/interceptors/base_url_interceptor.dart
+++ b/lib/src/api/interceptors/base_url_interceptor.dart
@@ -1,0 +1,18 @@
+import 'package:dio/dio.dart';
+
+class BaseUrlInterceptor extends Interceptor {
+  @override
+  onRequest(RequestOptions options) {
+    // Base Url is set, check base url ends with /
+    var baseUrl = options.baseUrl;
+    if (baseUrl != null && !baseUrl.endsWith("/")) {
+      throw ArgumentError("Base Url '$baseUrl' should end with '/'");
+    }
+    // Base Url is set and path starts with /, Start path from domain rather than base url
+    if (baseUrl != null && options.path.startsWith("/")) {
+      Uri uri = Uri.parse(baseUrl).replace(path: options.path);
+      options.path = uri.toString();
+    }
+    super.onRequest(options);
+  }
+}

--- a/test/mocks/mock_dio_client_adapter.dart
+++ b/test/mocks/mock_dio_client_adapter.dart
@@ -1,0 +1,28 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dio/dio.dart';
+
+class MockAdapter extends HttpClientAdapter {
+  static const String mockHost = "mockserver";
+  static const String mockBase = "http://$mockHost/";
+  DefaultHttpClientAdapter _defaultHttpClientAdapter =
+      DefaultHttpClientAdapter();
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>> requestStream, Future cancelFuture) async {
+    Uri uri = options.uri;
+    return ResponseBody.fromString(
+      jsonEncode({
+        "errCode": 0,
+        "data": {"path": uri.path}
+      }),
+      200,
+      DioHttpHeaders.fromMap({
+        HttpHeaders.contentTypeHeader: ContentType.json,
+      }),
+    );
+  }
+}

--- a/test/mocks/mock_dio_client_adapter.dart
+++ b/test/mocks/mock_dio_client_adapter.dart
@@ -15,10 +15,7 @@ class MockAdapter extends HttpClientAdapter {
       Stream<List<int>> requestStream, Future cancelFuture) async {
     Uri uri = options.uri;
     return ResponseBody.fromString(
-      jsonEncode({
-        "errCode": 0,
-        "data": {"path": uri.path}
-      }),
+      jsonEncode({"path": uri.path}),
       200,
       DioHttpHeaders.fromMap({
         HttpHeaders.contentTypeHeader: ContentType.json,

--- a/test/unit/base_url_interceptor_test.dart
+++ b/test/unit/base_url_interceptor_test.dart
@@ -1,0 +1,58 @@
+import 'package:dio/dio.dart';
+import 'package:flrx/src/api/interceptors/base_url_interceptor.dart';
+import 'package:test_api/test_api.dart';
+
+import '../mocks/mock_dio_client_adapter.dart';
+
+void main() {
+  group('Base Url Interceptor', () {
+    Dio dio;
+    setUp(() {
+      dio = new Dio();
+      dio.options.baseUrl = MockAdapter.mockBase;
+      dio.httpClientAdapter = MockAdapter();
+      dio.interceptors.add(BaseUrlInterceptor());
+    });
+
+    test('Test Base Url is invalid', () {
+      dio.options.baseUrl = "http://${MockAdapter.mockHost}";
+      expect(() => dio.get("test"), throwsA(const TypeMatcher<DioError>()));
+    });
+
+    test('Test Simple Base Url with path starting with /', () async {
+      //Test http://mockserver/test
+      var path = "/test";
+      Response response = await dio.get(path);
+      expect(response.data['data']['path'], path);
+      expect(response.data["errCode"], 0);
+
+      //Test http://mockserver/test/nested
+      path = "/test/nested";
+      response = await dio.get(path);
+      expect(response.data['data']['path'], path);
+      expect(response.data["errCode"], 0);
+    });
+
+    test('Test with nested Base Url with path starting with /', () async {
+      dio.options.baseUrl += "/api/";
+
+      //Test http://mockserver/
+      var path = "/";
+      Response response = await dio.get(path);
+      expect(response.data['data']['path'], "/");
+      expect(response.data["errCode"], 0);
+
+      //Test http://mockserver/api/
+      path = "";
+      response = await dio.get(path);
+      expect(response.data['data']['path'], "/api/");
+      expect(response.data["errCode"], 0);
+
+      //Test http://mockserver/api/test
+      path = "/test";
+      response = await dio.get(path);
+      expect(response.data['data']['path'], path);
+      expect(response.data["errCode"], 0);
+    });
+  });
+}

--- a/test/unit/base_url_interceptor_test.dart
+++ b/test/unit/base_url_interceptor_test.dart
@@ -23,14 +23,12 @@ void main() {
       //Test http://mockserver/test
       var path = "/test";
       Response response = await dio.get(path);
-      expect(response.data['data']['path'], path);
-      expect(response.data["errCode"], 0);
+      expect(response.data['path'], path);
 
       //Test http://mockserver/test/nested
       path = "/test/nested";
       response = await dio.get(path);
-      expect(response.data['data']['path'], path);
-      expect(response.data["errCode"], 0);
+      expect(response.data['path'], path);
     });
 
     test('Test with nested Base Url with path starting with /', () async {
@@ -39,20 +37,17 @@ void main() {
       //Test http://mockserver/
       var path = "/";
       Response response = await dio.get(path);
-      expect(response.data['data']['path'], "/");
-      expect(response.data["errCode"], 0);
+      expect(response.data['path'], "/");
 
       //Test http://mockserver/api/
       path = "";
       response = await dio.get(path);
-      expect(response.data['data']['path'], "/api/");
-      expect(response.data["errCode"], 0);
+      expect(response.data['path'], "/api/");
 
       //Test http://mockserver/api/test
       path = "/test";
       response = await dio.get(path);
-      expect(response.data['data']['path'], path);
-      expect(response.data["errCode"], 0);
+      expect(response.data['path'], path);
     });
   });
 }


### PR DESCRIPTION
Handles the following cases 

If Base Url does not end with '/'
Throw error

Base Url: `http://something.test/`
Path: `/user`
End Result: `http://something.test/user`

Base Url: `http://something.test/user`
Path: `profile`
End Result: `http://something.test/user/profile`

Base Url: `http://something.test/user`
Path: `/profile`
End Result: `http://something.test/profile`