### PR TITLE
Refactor Application to accept list of registrars

### DIFF
--- a/lib/application.dart
+++ b/lib/application.dart
@@ -1,13 +1,16 @@
 import 'package:flrx/components/error/error_handler.dart';
 import 'package:flrx/components/error/error_reporter.dart';
 import 'package:flrx/components/registrar/service_locator.dart';
+import 'package:flrx/components/registrar/service_registrar.dart';
 
 class Application {
   static final ServiceLocator serviceLocator = ServiceLocator();
 
-  static void init(
-      void Function() initApp, void Function(ServiceLocator) setupSingletons) {
-    setupSingletons(serviceLocator);
+  static void init(void Function() initApp,
+      {List<ServiceRegistrar> registrars}) {
+    registrars.forEach((serviceRegistrar) async {
+      await serviceRegistrar.register(serviceLocator);
+    });
     ErrorHandler.init(reporter: get<ErrorReporter>()).runApp(initApp);
   }
 

--- a/lib/components/registrar/base_registar.dart
+++ b/lib/components/registrar/base_registar.dart
@@ -1,0 +1,5 @@
+import 'package:flrx/components/registrar/service_registrar.dart';
+
+abstract class BaseRegistrar {
+  void register(ServiceRegistrar locator);
+}


### PR DESCRIPTION
Allow async registrations and simplify registrations to the service locator from 

```dart
Application.init(initApp, (ServiceLocator locator) {
  ConfigRegistrar('My Flavor').register(locator),
  CommonRegistrar().register(locator);
  CustomerRegistrar().register(locator);
});
```

to
```dart
Application.init(initApp, [
  ConfigRegistrar('My Flavor'),
  CommonRegistrar(),
  CustomerRegistrar(),
]);
```